### PR TITLE
crates.io publishing information

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,15 @@
 [package]
 name = "universal_wallet"
 version = "0.3.0"
-authors = ["Charles Cunningham <c.a.cunningham6@gmail.com>"]
+authors = ["Charles Cunningham <c.a.cunningham6@gmail.com>",
+            "Ivan Temchenko <35359595i@gmail.com"]
 edition = "2018"
 description = "Rust implementation of the Universal Wallet 2020 Specification"
 license = "Apache-2.0"
+homepage = "https://jolocom.com/"
+repository = "https://github.com/jolocom/wallet-rs"
+readme = "README.md"
+keywords = ["keri", "SSI", "jolocom", "blockchain", "did", "wallet"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Cargo.toml update to match expectations from crates.io. 
Required for docs.rs documentation publishing.