### PR TITLE
use hex explicitly for key bytes serde

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "universal_wallet"
-version = "0.3.4"
+version = "0.3.5"
 authors = ["Charles Cunningham <c.a.cunningham6@gmail.com>",
             "Ivan Temchenko <35359595i@gmail.com>"]
 edition = "2018"

--- a/src/contents/public_key_info.rs
+++ b/src/contents/public_key_info.rs
@@ -20,11 +20,11 @@ use crate::Error;
 pub struct PublicKeyInfo {
     /// key controller information.
     pub controller: Vec<String>,
-    #[serde(rename = "type")]
     /// variant of `KeyType` representing type of the key.
+    #[serde(rename = "type")]
     pub key_type: KeyType,
-    #[serde(rename = "publicKeyHex")]
     /// vector of bytes of public key.
+    #[serde(rename = "publicKeyHex", with = "hex")]
     pub public_key: Vec<u8>,
 }
 


### PR DESCRIPTION
fixes adding key contents with `publicKeyHex` and `privateKeyHex`